### PR TITLE
Use -chromedebug flag to start debugger.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -115,7 +115,8 @@ function getNLSConfiguration() {
 
 function findKhaAppParameter() {
 	var argv = process.argv.slice(1);
-	for (var i = 0; i < argv.length; i++) {
+	if (argv[0] !== '-chromedebug') return null;
+	for (var i = 1; i < argv.length; i++) {
 		if (argv[i].trim().length > 0 && argv[i] !== '.' && argv[i][0] !== '-') {
 			return argv[i];
 		}


### PR DESCRIPTION
This change allows to operate KodeStudio from command line. Depends on https://github.com/KTXSoftware/vscode-chrome-debug-core/pull/1.
